### PR TITLE
feature: sets nil to invoke function return type to make sure set an interface nil

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,10 +2,12 @@ package jin
 
 import (
 	"fmt"
-	"github.com/juanjiTech/inject/v2"
-	"github.com/juanjiTech/jin/render"
 	"math"
 	"net/http"
+	"reflect"
+
+	"github.com/juanjiTech/inject/v2"
+	"github.com/juanjiTech/jin/render"
 )
 
 // abortIndex represents a typical value used in abort functions.
@@ -70,8 +72,11 @@ func (c *Context) Next() {
 		}
 		c.index++
 
-		for _, val := range values {
-			c.Map(val.Interface())
+		fnType := reflect.TypeOf(h)
+		// ignore check fnType is nil or Func
+
+		for i, val := range values {
+			c.Set(fnType.Out(i), val)
 		}
 	}
 }

--- a/jin_test.go
+++ b/jin_test.go
@@ -1,10 +1,12 @@
 package jin
 
 import (
-	"github.com/juanjiTech/inject/v2"
+	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
+
+	"github.com/juanjiTech/inject/v2"
 )
 
 func TestDefaultEngine(t *testing.T) {
@@ -23,6 +25,31 @@ func TestDefaultEngine(t *testing.T) {
 		v++
 		_, _ = c.Writer.WriteString(strconv.Itoa(v))
 	})
+
+	respHandler := func(c *Context, v string, err error) {
+		t.Log("response handler:", v)
+		if err != nil {
+			t.Log("response error:", err)
+			_, _ = c.Writer.WriteString("error: " + err.Error())
+			return
+		}
+		_, _ = c.Writer.WriteString(v)
+		return
+	}
+
+	e.GET("/pong", func(v int) string {
+		t.Log("pong", v)
+		return "pong " + strconv.Itoa(v)
+	}, func(c string) {
+		t.Log("final", c)
+	}, respHandler)
+	e.GET("/error", func() (string, error) {
+		return "", fmt.Errorf("damn this is an error!")
+	}, respHandler)
+	e.GET("/noerror", func() (string, error) {
+		return "no error!", nil
+	}, respHandler)
+
 	e.GET("/panic", func() {
 		panic("I am panic")
 	})


### PR DESCRIPTION
as topic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handler return values are now injected by their declared output types (using reflect), preserving typed nils; tests add routes verifying string and (string, error) flows.
> 
> - **Context invocation**:
>   - Change `Context.Next` to inject handler return values by declared output types via `reflect.TypeOf(h)` and `c.Set(fnType.Out(i), val)` instead of `c.Map(val.Interface())`, ensuring typed `nil` preservation.
> - **Tests**:
>   - Extend `jin_test.go` with routes `/pong`, `/error`, and `/noerror` and a shared `respHandler` to verify propagation of returned values and `(value, error)` patterns.
>   - Minor imports adjustments (add `reflect`, `fmt`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a853048dc51bb23b6f66c7e251493497896297b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route registration now supports a per-route response handler for centralized processing and logging.

* **Bug Fixes**
  * Improved handling of multiple return values from route handlers to ensure correct response mapping.

* **Tests**
  * Added tests covering response handling, error scenarios, and the new per-route response processing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->